### PR TITLE
add scikit-learn version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ scipy
 spfpm==1.4
 gspread==3.6.0
 oauth2client==4.1.3
-sklearn
+scikit-learn==0.22.2.post1
 auto-sklearn==0.9.0
 arff==0.9
 kaleido


### PR DESCRIPTION
I was getting the following error running the validation notebook within the venv. This attempts to fix that  
`Trying to unpickle estimator from version 0.22.2.post1 when using version 0.23.2. This might lead to breaking code or invalid results. Use at your own risk.`